### PR TITLE
Add installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ An inspiration for this plugin was a Google Developers guide around
 
 ## Installation
 
-Copy the plugin files to the `wp-content/plugins` folder inside your WordPress directory.
+This plugin must be installed as [a Composer dependency](https://packagist.org/packages/xwp/site-performance-tracker):
+
+    composer require xwp/site-performance-tracker
+
+It relies on [PSR-4 autoloading](https://getcomposer.org/doc/04-schema.md#psr-4) as defined in the [`composer.json` file](composer.json).
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Site Performance Tracker
-=============
+# Site Performance Tracker
 
 This WordPress plugin allows you to detect and track site performance metrics.
 It is using a browser's [`PerformanceObserver`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ An inspiration for this plugin was a Google Developers guide around
 
 This plugin must be installed as [a Composer dependency](https://packagist.org/packages/xwp/site-performance-tracker):
 
-    composer require xwp/site-performance-tracker
+```
+composer require xwp/site-performance-tracker
+```
 
 It relies on [PSR-4 autoloading](https://getcomposer.org/doc/04-schema.md#psr-4) as defined in the [`composer.json` file](composer.json).
 


### PR DESCRIPTION
Fixes #10.

- [x] Describe that we currently only support Composer for installation.
- [ ] Describe Google Analytics setup requirements. Do we currently only support sites that have `ga()` defined in the `<head>`? Do we support [the new `gtag.js` tags](https://support.google.com/analytics/answer/1008080)?