### PR TITLE
Resolve plugin activation error in WordPress

### DIFF
--- a/site-performance-tracker.php
+++ b/site-performance-tracker.php
@@ -57,4 +57,5 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 require_once __DIR__ . '/php/helpers.php';
 
 // Initialize the plugin.
+require_once __DIR__ . '/php/Plugin.php';
 add_action( 'init', array( new \Site_Performance_Tracker\Plugin(), 'init' ) );


### PR DESCRIPTION
Using the latest commit from the master branch, I was unable to activate the plugin and was shown the following error:

```
Fatal error: Uncaught Error: Class 'Site_Performance_Tracker\Plugin' not found in /home/user/public_html/wp-content/plugins/site-performance-tracker-0.2.0/site-performance-tracker.php:60 Stack trace: #0 /home/user/public_html/wp-admin/includes/plugin.php(2050): include() #1 /home/user/public_html/wp-admin/plugins.php(175): plugin_sandbox_scrape('site-performanc...') #2 {main} thrown in /home/user/public_html/wp-content/plugins/site-performance-tracker-0.2.0/site-performance-tracker.php on line 60
```

Explicitly importing the `Plugin.php` file resolved the error. Maybe this import was supposed to be handled implicitly, though let me know if I've misunderstood something. Please and thank you!

### Environment Information
```
Host OS:   CentOS Linux release 7.6.1810 (Core)
Kernel:    Linux 3.10.0-957.5.1.el7.x86_64
PHP:       PHP 7.3.3 (cgi-fcgi) (built: Mar 12 2019 03:50:47)
WordPress: v5.1.1
````

Edit 1: typo
Edit 2: wrap error in code tags so that it doesn't reference open issues