### PR TITLE
Ignore code sniffer error

### DIFF
--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -208,7 +208,7 @@ class Plugin {
 			return;
 		}
 
-		echo '<script>' . $mark . '</script>' . PHP_EOL; // XSS ok.
+		echo '<script>' . $mark . '</script>' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
 	/**


### PR DESCRIPTION
This PR is for correctly ignoring the code sniffer error for `WordPressVIPMinimum` coding standard