### PR TITLE
Fix gtag configuration function

### DIFF
--- a/js/src/web-vitals-analytics.js
+++ b/js/src/web-vitals-analytics.js
@@ -132,7 +132,7 @@ function getDebugInfo( metricName, entries = [] ) {
 
 function sendToGoogleAnalytics( { name, value, delta, id, entries } ) {
 	if ( window.webVitalsAnalyticsData.gtag_id ) {
-		configureGtag();
+		configureGtag( window.webVitalsAnalyticsData.gtag_id );
 		getDeliveryFunction( 'gtag' )( 'event', name, {
 			event_category: 'Web Vitals',
 			event_label: id,


### PR DESCRIPTION
The configuration function call did not include measurement id, this is why the debugging dimensions did not work.