### PR TITLE
Fix to hardcoded data in settings screen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ add_theme_support( 'site_performance_tracker_vitals', array(
 ) );
 ```
 
-The following hooks can be added to a theme or a custom plugin to configure the plugin. To confirm they were applied look for the `webVitalsAnalyticsData` global variable in the page source.
+The following hooks can be added to a theme or a custom plugin to configure the plugin, alternatively you can configure the plugin through the settings screen, in case of duplication, plugin will take programmatically set settings. To confirm they were applied look for the `webVitalsAnalyticsData` global variable in the page source.
 
 ### Limit the number of events sent
 
@@ -98,6 +98,10 @@ All contributions are welcome! Please create [an issue](https://github.com/xwp/s
 
 
 ## Changelog
+
+#### 1.1.3 - March 9, 2022
+
+Fix UI to prefill configured data.
 
 #### 1.1.2 - March 4, 2022
 

--- a/php/views/settings.php
+++ b/php/views/settings.php
@@ -7,12 +7,14 @@
 
 use XWP\Site_Performance_Tracker\Plugin;
 
-// Get options set via add_theme_support.
-function ga_xwp() {
+/**
+ * Get options set via add_theme_support.
+ */
+function get_hardcoded_tracker_config() {
 	global $tracker_config;
 	$tracker_config = isset( get_theme_support( 'site_performance_tracker_vitals' )[0] ) ? get_theme_support( 'site_performance_tracker_vitals' )[0] : array();
 }
-add_action( 'after_setup_theme', 'ga_xwp', PHP_INT_MAX );
+add_action( 'after_setup_theme', 'get_hardcoded_tracker_config', PHP_INT_MAX );
 
 /**
  * Get available trackers and print 'readonly' in the form inputs if the setting is defined in theme files
@@ -29,16 +31,15 @@ function print_readonly( $prop_name ) {
 /**
  * Add tracker as a settings menu item.
  */
-add_action( 'admin_menu', 'spt_add_admin_menu' );
 function spt_add_admin_menu() {
 	add_options_page( 'Site Performance Tracker', 'Site Performance Tracker', 'manage_options', 'site_performance_tracker', 'spt_options_page' );
 }
+add_action( 'admin_menu', 'spt_add_admin_menu' );
 
 /**
  * Initialize tracker settings by registering it and adding
  * sections and fields.
  */
-add_action( 'admin_init', 'spt_settings_init' );
 function spt_settings_init() {
 	register_setting( 'pluginPage', 'spt_settings' );
 
@@ -97,6 +98,7 @@ function spt_settings_init() {
 		'spt_pluginPage_section'
 	);
 }
+add_action( 'admin_init', 'spt_settings_init' );
 
 /**
  * Render Analytics Types form dropdown.

--- a/php/views/settings.php
+++ b/php/views/settings.php
@@ -8,7 +8,11 @@
 use XWP\Site_Performance_Tracker\Plugin;
 
 // Get options set via add_theme_support.
-$tracker_config = isset( get_theme_support( 'site_performance_tracker_vitals' )[0] ) ? get_theme_support( 'site_performance_tracker_vitals' )[0] : array();
+function ga_xwp() {
+	global $tracker_config;
+	$tracker_config = isset( get_theme_support( 'site_performance_tracker_vitals' )[0] ) ? get_theme_support( 'site_performance_tracker_vitals' )[0] : array();
+}
+add_action( 'after_setup_theme', 'ga_xwp', PHP_INT_MAX );
 
 /**
  * Get available trackers and print 'readonly' in the form inputs if the setting is defined in theme files
@@ -22,12 +26,10 @@ function print_readonly( $prop_name ) {
 	}
 }
 
-add_action( 'admin_menu', 'spt_add_admin_menu' );
-add_action( 'admin_init', 'spt_settings_init' );
-
 /**
  * Add tracker as a settings menu item.
  */
+add_action( 'admin_menu', 'spt_add_admin_menu' );
 function spt_add_admin_menu() {
 	add_options_page( 'Site Performance Tracker', 'Site Performance Tracker', 'manage_options', 'site_performance_tracker', 'spt_options_page' );
 }
@@ -36,6 +38,7 @@ function spt_add_admin_menu() {
  * Initialize tracker settings by registering it and adding
  * sections and fields.
  */
+add_action( 'admin_init', 'spt_settings_init' );
 function spt_settings_init() {
 	register_setting( 'pluginPage', 'spt_settings' );
 
@@ -230,9 +233,20 @@ function event_debug_dimension_render() {
  */
 function web_vitals_tracking_ratio_render() {
 	$options = spt_get_settings();
+	global $tracker_config;
+	$set = false;
+	if ( isset( $tracker_config['web_vitals_tracking_ratio'] ) ) {
+		$options['web_vitals_tracking_ratio'] = $tracker_config['web_vitals_tracking_ratio'];
+		$set = true;
+	}
 	?>
-	<input type='number' name='spt_settings[web_vitals_tracking_ratio]' step='0.01' min='0.01' max='1' value='<?php echo esc_attr( $options['web_vitals_tracking_ratio'] ); ?>' placeholder="Enter between 0 > 1" aria-label="web vitals tracking ratio">
+	<input type='number' name='spt_settings[web_vitals_tracking_ratio]' step='0.01' min='0.01' max='1' value='<?php echo esc_attr( $options['web_vitals_tracking_ratio'] ); ?>' placeholder="Enter between 0 > 1" aria-label="web vitals tracking ratio" <?php print_readonly( 'web_vitals_tracking_ratio' ); ?>>
 	<?php
+	if ( $set ) {
+		?>
+		<br /><small><?php esc_html_e( 'Configured via theme files', 'site-performance-tracker' ); ?></small>
+		<?php
+	}
 }
 
 /**

--- a/site-performance-tracker.php
+++ b/site-performance-tracker.php
@@ -8,7 +8,7 @@
  * Plugin Name: Site Performance Tracker
  * Plugin URI: https://github.com/xwp/site-performance-tracker
  * Description: Allows you to detect and track site performance metrics.
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: XWP.co
  * Author URI: https://xwp.co
  */


### PR DESCRIPTION
<!-- Please specify the related issue. -->
Fixes [#56](https://github.com/xwp/site-performance-tracker/issues/56)

## Tasks

- [x] UI settings fixed when hardcoded config.
- [x] Ratio setting was not checking if config was hardcoded. 


## Describe the Approach

- Global $tracker_config wasn't defined properly. 