### PR TITLE
Fix `ga_id` when using UI settings

### DIFF
--- a/php/src/class-plugin.php
+++ b/php/src/class-plugin.php
@@ -91,6 +91,11 @@ class Plugin {
 		 * Load only for modern browsers
 		 */
 		add_filter( 'script_loader_tag', array( $this, 'optimize_scripts' ), 10, 2 );
+
+		/**
+		 * Update and validate settings before updating
+		 */
+		add_filter( 'pre_update_option_spt_settings', array( $this, 'pre_update_option' ), 10, 1 );
 	}
 
 	/**
@@ -221,5 +226,20 @@ class Plugin {
 		}
 
 		return $tag;
+	}
+
+	/**
+	 * Filter the spt_settings options before updated
+	 *
+	 * @param array $value The new, unserialized option value.
+	 * @return array $value
+	 */
+	public function pre_update_option( $value ) {
+		if ( isset( $value['analytics_types'] ) && 'ga_id' == $value['analytics_types'] ) {
+			$value['ga_id'] = $value['gtag_id'];
+			unset( $value['gtag_id'] );
+		}
+
+		return $value;
 	}
 }

--- a/php/views/settings.php
+++ b/php/views/settings.php
@@ -145,6 +145,11 @@ function analytics_id_render() {
 	global $tracker_config;
 	$set = false;
 	$prop = 'gtag_id';
+
+	if ( isset( $options['ga_id'] ) ) {
+		$options['gtag_id'] = $options['ga_id'];
+	}
+
 	if ( isset( $tracker_config['ga_id'] ) ) {
 		$options['gtag_id'] = $tracker_config['ga_id'];
 		$prop = 'ga_id';


### PR DESCRIPTION
<!-- Please specify the related issue. -->
Fixes #71

## Tasks

- [x] Fix `ga_id` is not initialised correctly via the UI settings


## Describe the Approach

- Validate the option values before saving and update the array index appropriately
