### PR TITLE
Create GA tracker object before the event

### DIFF
--- a/js/src/send-to-analytics.js
+++ b/js/src/send-to-analytics.js
@@ -147,6 +147,7 @@ export function sendToAnalytics( { name, value, delta, id, entries } ) {
 		} );
 	}
 	if ( analyticsData && analyticsData.ga_id ) {
+		getDeliveryFunction( 'ga' )( 'create', analyticsData.ga_id, 'auto' );
 		getDeliveryFunction( 'ga' )( 'send', 'event', {
 			eventCategory: 'Web Vitals',
 			eventAction: name,


### PR DESCRIPTION
<!-- Please specify the related issue. -->
Fixes #73 by introducing the following:

## Tasks
- [x] Create GA tracker object before the event

## Describe the Approach
As described [here](https://developers.google.com/analytics/devguides/collection/analyticsjs), GA delivery would require the tracker object created before the event. This is the fix that has been introduced in this PR.
