### PR TITLE
Fix docblock of Plugin::optimize_scripts

### DIFF
--- a/php/src/class-plugin.php
+++ b/php/src/class-plugin.php
@@ -220,7 +220,7 @@ class Plugin {
 	 * @param string $tag Script tag mark-up.
 	 * @param string $handle Script ID.
 	 *
-	 * @return $tag
+	 * @return string
 	 */
 	public function optimize_scripts( $tag, $handle ) {
 		// Replaces only the first occurrence of src in the tag. Avoids replacing inside inline scripts.


### PR DESCRIPTION
## Tasks

- [x] One important change that has been implemented.
- [ ] Another thing still left to do.
- [ ] Added PHP tests.
- [ ] Added JS tests.


## Describe the Approach

Static analysis found an invalid `@return` tag.
Please consider using it.
