### PR TITLE
Introduce autoloader

### DIFF
--- a/site-performance-tracker.php
+++ b/site-performance-tracker.php
@@ -21,8 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Admin notice for incompatible versions of PHP.
  */
-function site_performance_tracker_php_version_error() {
-	printf( '<div class="error"><p>%s</p></div>', esc_html( site_performance_tracker_php_version_text() ) );
+function xwp_site_performance_tracker_php_version_error() {
+	printf( '<div class="error"><p>%s</p></div>', esc_html( xwp_site_performance_tracker_php_version_text() ) );
 }
 
 /**
@@ -33,40 +33,9 @@ function site_performance_tracker_php_version_error() {
  *
  * @return string
  */
-function site_performance_tracker_php_version_text() {
+function xwp_site_performance_tracker_php_version_text() {
 	return __( 'Site Performance Tracker plugin error: Your version of PHP is too old to run this plugin. You must be running PHP 5.3 or higher.', 'site-performance-tracker' );
 }
-
-// If the PHP version is too low, show warning and return.
-if ( version_compare( phpversion(), '5.3', '<' ) ) {
-	if ( defined( 'WP_CLI' ) ) {
-		WP_CLI::warning( site_performance_tracker_php_version_text() );
-	} else {
-		add_action( 'admin_notices', 'site_performance_tracker_php_version_error' );
-	}
-
-	return;
-}
-
-/**
- * Use includes to simplify the plugin distribution and usage on
- * platforms on platforms that don't use Composer autoloader.
- *
- * @todo Consider supporting Composer classmap autoload (to match
- * the filename requirements per PHPCS) after figuring out
- * how to handle built JS and the presence of `vendor` directory.
- */
-require_once __DIR__ . '/php/src/class-plugin.php';
-require_once __DIR__ . '/php/src/class-settings.php';
-require_once __DIR__ . '/php/src/class-fieldbase.php';
-require_once __DIR__ . '/php/src/class-dimensionfieldbase.php';
-require_once __DIR__ . '/php/src/class-analyticstypesfield.php';
-require_once __DIR__ . '/php/src/class-analyticsidfield.php';
-require_once __DIR__ . '/php/src/class-measurementversiondimensionfield.php';
-require_once __DIR__ . '/php/src/class-eventmetadimensionfield.php';
-require_once __DIR__ . '/php/src/class-eventdebugdimensionfield.php';
-require_once __DIR__ . '/php/src/class-webvitalstrackingratiofield.php';
-require_once __DIR__ . '/php/helpers.php';
 
 /**
  * Global function to provide access to the plugin APIs.
@@ -82,6 +51,55 @@ function xwp_site_performance_tracker() {
 
 	return $plugin;
 }
+
+/**
+ * Global function to provide access to the plugin APIs.
+ *
+ * @param class-string $class_name The fully-qualified class name.
+ *
+ * @return void
+ */
+function xwp_site_performance_autoloader( $class_name ) {
+	$project_namespace = 'XWP\\Site_Performance_Tracker\\';
+	$length = strlen( $project_namespace );
+
+	// Class is not in our namespace.
+	if ( 0 !== strncmp( $project_namespace, $class_name, $length ) ) {
+		return;
+	}
+
+	$relative_class_name = substr( $class_name, $length );
+	$name_parts = explode( '\\', strtolower( str_replace( '_', '-', $relative_class_name ) ) );
+	$last_part  = array_pop( $name_parts );
+
+	$file = sprintf(
+		'%1$s/php/src%2$s/class-%3$s.php',
+		__DIR__,
+		array() === $name_parts ? '' : '/' . implode( '/', $name_parts ),
+		$last_part
+	);
+
+	if ( ! is_file( $file ) ) {
+		return;
+	}
+
+	require $file;
+}
+
+// If the PHP version is too low, show warning and return.
+if ( version_compare( phpversion(), '5.3', '<' ) ) {
+	if ( defined( 'WP_CLI' ) ) {
+		WP_CLI::warning( xwp_site_performance_tracker_php_version_text() );
+	} else {
+		add_action( 'admin_notices', 'xwp_site_performance_tracker_php_version_error' );
+	}
+
+	return;
+}
+
+// Register autoloader and load helpers.
+spl_autoload_register( 'xwp_site_performance_autoloader' );
+require_once __DIR__ . '/php/helpers.php';
 
 // Initialize the plugin.
 add_action( 'init', array( xwp_site_performance_tracker(), 'init' ) );


### PR DESCRIPTION
Fixes a `@todo`

## Tasks

- [x] One important change that has been implemented.
- [ ] Another thing still left to do.
- [ ] Added PHP tests.
- [ ] Added JS tests.


## Describe the Approach

- fixed prefix of `site_performance_tracker_php_version_error`
- moved all functions to the top of the main file to separate definitions from side-effects
- added `xwp_site_performance_autoloader`

[_source_](https://github.com/szepeviktor/debian-server-tools/blob/master/webserver/wp-install/wordpress-autoloader.php)
