### PR TITLE
Update GA4 ID setting

### DIFF
--- a/php/src/class-analyticsidfield.php
+++ b/php/src/class-analyticsidfield.php
@@ -71,7 +71,7 @@ final class AnalyticsIdField extends FieldBase {
 			$display_theme_override_warning = true;
 		} elseif ( isset( $hardcoded_tracker_config[ self::OPTION_GA4_ID ] ) ) {
 			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config[ self::OPTION_GA4_ID ];
-			$property_name                  =  self::OPTION_GA4_ID ;
+			$property_name                  = self::OPTION_GA4_ID;
 			$display_theme_override_warning = true;
 		}
 		?>

--- a/php/src/class-analyticsidfield.php
+++ b/php/src/class-analyticsidfield.php
@@ -19,13 +19,19 @@ final class AnalyticsIdField extends FieldBase {
 	 */
 	const OPTION_TAG_ID = 'gtag_id';
 
-
 	/**
-	 * Option gtag_id name.
+	 * Option ga_id name.
 	 *
 	 * @var string
 	 */
-	const OPTION_ANALYTICS_ID = 'analytics_id';
+	const OPTION_ANALYTICS_ID = 'ga_id';
+
+	/**
+	 * Option ga4_id name.
+	 *
+	 * @var string
+	 */
+	const OPTION_GA4_ID = 'ga4_id';
 
 	/**
 	 * Get current field id.
@@ -50,25 +56,25 @@ final class AnalyticsIdField extends FieldBase {
 		$display_theme_override_warning  = false;
 		$property_name = self::OPTION_TAG_ID;
 
-		if ( isset( $options['ga_id'] ) ) {
-			$options[ self::OPTION_TAG_ID ] = $options['ga_id'];
+		if ( isset( $options[ self::OPTION_ANALYTICS_ID ] ) ) {
+			$options[ self::OPTION_TAG_ID ] = $options[ self::OPTION_ANALYTICS_ID ];
 		}
 
-		if ( isset( $hardcoded_tracker_config['ga_id'] ) ) {
-			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config['ga_id'];
-			$property_name                  = 'ga_id';
+		if ( isset( $hardcoded_tracker_config[ self::OPTION_ANALYTICS_ID ] ) ) {
+			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config[ self::OPTION_ANALYTICS_ID ];
+			$property_name                  = self::OPTION_ANALYTICS_ID;
 			$display_theme_override_warning = true;
 		} elseif ( isset( $hardcoded_tracker_config[ self::OPTION_TAG_ID ] ) ) {
 			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config[ self::OPTION_TAG_ID ];
-			$display_theme_override_warning                            = true;
-		} elseif ( isset( $hardcoded_tracker_config['ga4_id'] ) ) {
-			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config['ga4_id'];
-			$property_name                  = 'ga4_id';
+			$display_theme_override_warning = true;
+		} elseif ( isset( $hardcoded_tracker_config[ self::OPTION_GA4_ID ] ) ) {
+			$options[ self::OPTION_TAG_ID ] = $hardcoded_tracker_config[ self::OPTION_GA4_ID ];
+			$property_name                  =  self::OPTION_GA4_ID ;
 			$display_theme_override_warning = true;
 		}
 		?>
-		<input type='text' name='spt_settings[<?php echo esc_attr( self::OPTION_TAG_ID ); ?>]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="UA-XXXXXXXX-Y"
+		<input type='text' name='spt_settings[<?php echo esc_attr( self::OPTION_TAG_ID ); ?>]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="Analytics ID"
 			   aria-label="<?php echo esc_attr( __( 'analytics id', 'site-performance-tracker' ) ); ?>" <?php $this->print_readonly( $property_name ); ?> required>
 		<?php
 

--- a/php/src/class-analyticsidfield.php
+++ b/php/src/class-analyticsidfield.php
@@ -58,6 +58,8 @@ final class AnalyticsIdField extends FieldBase {
 
 		if ( isset( $options[ self::OPTION_ANALYTICS_ID ] ) ) {
 			$options[ self::OPTION_TAG_ID ] = $options[ self::OPTION_ANALYTICS_ID ];
+		} elseif ( isset( $options[ self::OPTION_GA4_ID ] ) ) {
+			$options[ self::OPTION_TAG_ID ] = $options[ self::OPTION_GA4_ID ];
 		}
 
 		if ( isset( $hardcoded_tracker_config[ self::OPTION_ANALYTICS_ID ] ) ) {

--- a/php/src/class-analyticsidfield.php
+++ b/php/src/class-analyticsidfield.php
@@ -76,7 +76,7 @@ final class AnalyticsIdField extends FieldBase {
 		}
 		?>
 		<input type='text' name='spt_settings[<?php echo esc_attr( self::OPTION_TAG_ID ); ?>]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="UA-XXX | G-XXX | GTM-XXX"
+			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="UA-XXX | GTM-XXX | G-XXX"
 			   aria-label="<?php echo esc_attr( __( 'analytics id', 'site-performance-tracker' ) ); ?>" <?php $this->print_readonly( $property_name ); ?> required>
 		<?php
 

--- a/php/src/class-analyticsidfield.php
+++ b/php/src/class-analyticsidfield.php
@@ -76,7 +76,7 @@ final class AnalyticsIdField extends FieldBase {
 		}
 		?>
 		<input type='text' name='spt_settings[<?php echo esc_attr( self::OPTION_TAG_ID ); ?>]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="Analytics ID"
+			   value='<?php echo esc_attr( $options[ self::OPTION_TAG_ID ] ); ?>' placeholder="UA-XXX | G-XXX | GTM-XXX"
 			   aria-label="<?php echo esc_attr( __( 'analytics id', 'site-performance-tracker' ) ); ?>" <?php $this->print_readonly( $property_name ); ?> required>
 		<?php
 

--- a/php/src/class-analyticstypesfield.php
+++ b/php/src/class-analyticstypesfield.php
@@ -40,13 +40,13 @@ class AnalyticsTypesField extends FieldBase {
 		$options = $this->settings->get_settings();
 		$hardcoded_tracker_config = $this->settings->get_hardcoded_tracker_config();
 		$display_theme_override_warning = false;
-		if ( isset( $hardcoded_tracker_config['ga_id'] ) ) {
-			$options[ self::OPTION_ANALYTICS_TYPES ] = 'ga_id';
+		if ( isset( $hardcoded_tracker_config[ AnalyticsIdField::OPTION_ANALYTICS_ID ] ) ) {
+			$options[ self::OPTION_ANALYTICS_TYPES ] = AnalyticsIdField::OPTION_ANALYTICS_ID;
 			$display_theme_override_warning          = true;
 		} elseif ( isset( $hardcoded_tracker_config[ AnalyticsIdField::OPTION_TAG_ID ] ) ) {
 			$options[ self::OPTION_ANALYTICS_TYPES ] = 'gtm';
 			$display_theme_override_warning          = true;
-		} elseif ( isset( $hardcoded_tracker_config['ga4_id'] ) ) {
+		} elseif ( isset( $hardcoded_tracker_config[ AnalyticsIdField::OPTION_GA4_ID ] ) ) {
 			$options[ self::OPTION_ANALYTICS_TYPES ] = 'ga4';
 			$display_theme_override_warning          = true;
 		}

--- a/site-performance-tracker.php
+++ b/site-performance-tracker.php
@@ -8,7 +8,7 @@
  * Plugin Name: Site Performance Tracker
  * Plugin URI: https://github.com/xwp/site-performance-tracker
  * Description: Allows you to detect and track site performance metrics.
- * Version: 1.3
+ * Version: 1.3.1
  * Author: XWP.co
  * Author URI: https://xwp.co
  */

--- a/tests/phpunit/class-test-settings.php
+++ b/tests/phpunit/class-test-settings.php
@@ -419,8 +419,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='' placeholder="Analytics ID"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -437,8 +437,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='test_ga_id' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='test_ga_id' placeholder="Analytics ID"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -455,8 +455,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='test_gtag_id' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='test_gtag_id' placeholder="Analytics ID"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -474,8 +474,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='test_ga_id' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='test_ga_id' placeholder="Analytics ID"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -494,8 +494,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='test_gtag_id' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='test_gtag_id' placeholder="Analytics ID"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -514,8 +514,8 @@ EOD;
 		ob_end_clean();
 
 		$expected_html = <<<EOD
-			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]+-[A-Z|0-9]+.*"
-				value='test_ga4_id' placeholder="UA-XXXXXXXX-Y"
+			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
+				value='test_ga4_id' placeholder="Analytics ID"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;

--- a/tests/phpunit/class-test-settings.php
+++ b/tests/phpunit/class-test-settings.php
@@ -117,7 +117,7 @@ class Test_Settings extends WP_UnitTestCase {
 
 		$this->settings->settings_init();
 
-		$field_name = 'analytics_id';
+		$field_name = 'ga_id';
 		$this->assertTrue( isset( $wp_settings_fields['pluginPage']['spt_pluginPage_section'][ $field_name ] ) );
 		$field = $wp_settings_fields['pluginPage']['spt_pluginPage_section'][ $field_name ];
 

--- a/tests/phpunit/class-test-settings.php
+++ b/tests/phpunit/class-test-settings.php
@@ -122,7 +122,7 @@ class Test_Settings extends WP_UnitTestCase {
 		$field = $wp_settings_fields['pluginPage']['spt_pluginPage_section'][ $field_name ];
 
 		$this->assertSame( $field_name, $field['id'] );
-		$this->assertSame( 'UA-XXX | G-XXX | GTM-XXX', $field['title'] );
+		$this->assertSame( 'UA-XXX | GTM-XXX | G-XXX', $field['title'] );
 
 		$this->assertSame( array( $this->settings->fields[1], 'render' ), $field['callback'] );
 
@@ -420,7 +420,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -438,7 +438,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='test_ga_id' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -456,7 +456,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_gtag_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='test_gtag_id' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -475,7 +475,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='test_ga_id' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -495,7 +495,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_gtag_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='test_gtag_id' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -515,7 +515,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga4_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
+				value='test_ga4_id' placeholder="UA-XXX | GTM-XXX | G-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;

--- a/tests/phpunit/class-test-settings.php
+++ b/tests/phpunit/class-test-settings.php
@@ -122,7 +122,7 @@ class Test_Settings extends WP_UnitTestCase {
 		$field = $wp_settings_fields['pluginPage']['spt_pluginPage_section'][ $field_name ];
 
 		$this->assertSame( $field_name, $field['id'] );
-		$this->assertSame( 'Analytics ID', $field['title'] );
+		$this->assertSame( 'UA-XXX | G-XXX | GTM-XXX', $field['title'] );
 
 		$this->assertSame( array( $this->settings->fields[1], 'render' ), $field['callback'] );
 
@@ -420,7 +420,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='' placeholder="Analytics ID"
+				value='' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -438,7 +438,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga_id' placeholder="Analytics ID"
+				value='test_ga_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -456,7 +456,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_gtag_id' placeholder="Analytics ID"
+				value='test_gtag_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id"  required>
 EOD;
 
@@ -475,7 +475,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga_id' placeholder="Analytics ID"
+				value='test_ga_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -495,7 +495,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_gtag_id' placeholder="Analytics ID"
+				value='test_gtag_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;
@@ -515,7 +515,7 @@ EOD;
 
 		$expected_html = <<<EOD
 			<input type='text' name='spt_settings[gtag_id]' pattern="[UA|GTM|G]-[A-Z0-9](.*)?"
-				value='test_ga4_id' placeholder="Analytics ID"
+				value='test_ga4_id' placeholder="UA-XXX | G-XXX | GTM-XXX"
 				aria-label="analytics id" readonly required>
 			<br/><small>Configured via theme files</small>
 EOD;

--- a/tests/phpunit/class-test-settings.php
+++ b/tests/phpunit/class-test-settings.php
@@ -122,7 +122,7 @@ class Test_Settings extends WP_UnitTestCase {
 		$field = $wp_settings_fields['pluginPage']['spt_pluginPage_section'][ $field_name ];
 
 		$this->assertSame( $field_name, $field['id'] );
-		$this->assertSame( 'UA-XXX | GTM-XXX | G-XXX', $field['title'] );
+		$this->assertSame( 'Analytics ID', $field['title'] );
 
 		$this->assertSame( array( $this->settings->fields[1], 'render' ), $field['callback'] );
 


### PR DESCRIPTION
<!-- Please specify the related issue. -->
Fixes #109 

## Tasks

- [x] Make variables from static content used more than once.
- [x] Add support for GA4 id setting


## Describe the Approach

- Most of the static content was hard-coded directly into the nodes. I created variable for these and updated references so that we have 1 source of truth for the static elements.
- GA4 analytics type wasn't supported in the input, I added the support.


<!-- Delete this section for regular pull requests. -->
## Release Checklist

- [x] Review the release guidelines in the [contribution documentation](https://github.com/xwp/site-performance-tracker/blob/master/CONTRIBUTE.md).
- [x] Update the plugin `Version:` header value in `site-performance-tracker.php`.
- [x] Confirm that automated tests are passing for this pull request.
