### PR TITLE
Add non_interaction: true to perf events

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ All contributions are welcome! Please create [an issue](https://github.com/xwp/s
 
 ### Changelog
 
+#### 1.3.6 - Jan 14th, 2025
+
+- Made events non_interactive, such that they don't interfere with user events.
+
 #### 1.3.5 - Jul 28th, 2023
 
 - Add tracking support for Google Tag Manager setup GA4 with window.dataLayer.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All contributions are welcome! Please create [an issue](https://github.com/xwp/s
 
 #### 1.3.6 - Jan 14th, 2025
 
-- Made events non_interactive, such that they don't interfere with user events.
+- Made events non_interaction, such that they don't interfere with user events.
 
 #### 1.3.5 - Jul 28th, 2023
 

--- a/js/src/send-to-analytics.js
+++ b/js/src/send-to-analytics.js
@@ -22,6 +22,7 @@ export function sendToAnalytics( { name, value, delta, id, attribution, rating }
 		metric_value: value,
 		metric_delta: Math.round( name === 'CLS' ? delta * 1000 : delta ),
 		metric_rating: rating,
+		non_interactive: true,
 	};
 
 	switch ( name ) {

--- a/js/src/send-to-analytics.js
+++ b/js/src/send-to-analytics.js
@@ -22,7 +22,7 @@ export function sendToAnalytics( { name, value, delta, id, attribution, rating }
 		metric_value: value,
 		metric_delta: Math.round( name === 'CLS' ? delta * 1000 : delta ),
 		metric_rating: rating,
-		non_interactive: true,
+		non_interaction: true,
 	};
 
 	switch ( name ) {

--- a/site-performance-tracker.php
+++ b/site-performance-tracker.php
@@ -8,7 +8,7 @@
  * Plugin Name: Site Performance Tracker
  * Plugin URI: https://github.com/xwp/site-performance-tracker
  * Description: Allows you to detect and track site performance metrics.
- * Version: 1.3.5
+ * Version: 1.3.6
  * Author: XWP.co
  * Author URI: https://xwp.co
  */


### PR DESCRIPTION
<!-- Please specify the related issue. -->
Fixes a report that sometimes the performance events influence other GA4 metrics like AET (Active Engagement Time)

## Tasks

- [x] Send events with the non_interaction flag set to true.

## Describe the Approach

- Changed the eventParams base to include the flag

<!-- Delete this section for regular pull requests. -->
## Release Checklist

- [x] Review the release guidelines in the [contribution documentation](https://github.com/xwp/site-performance-tracker/blob/master/CONTRIBUTE.md).
- [x] Update the plugin `Version:` header value in `site-performance-tracker.php`.
- [ ] Confirm that automated tests are passing for this pull request.
